### PR TITLE
Add pushb command to auto-push new branches

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -22,4 +22,4 @@
     --abbrev-commit \
     --decorate \
     --format=format:'%C(bold blue)%h%C(reset) - %C(bold cyan)%aD%C(reset) %C(bold green)(%ar)%C(reset) %C(bold cyan)(committed: %cD)%C(reset) %C(auto)%d%C(reset)%n''          %C(white)%s%C(reset)%n''          %C(dim white)- %an <%ae> %C(reset) %C(dim white)(committer: %cn <%ce>)%C(reset)'
-  pushb = !"git push --set-upstream <(git remote) <(git symbolic-ref HEAD --short)"
+  pushb = !"git push --set-upstream $(git remote) $(git symbolic-ref HEAD --short)"

--- a/.gitconfig
+++ b/.gitconfig
@@ -22,3 +22,4 @@
     --abbrev-commit \
     --decorate \
     --format=format:'%C(bold blue)%h%C(reset) - %C(bold cyan)%aD%C(reset) %C(bold green)(%ar)%C(reset) %C(bold cyan)(committed: %cD)%C(reset) %C(auto)%d%C(reset)%n''          %C(white)%s%C(reset)%n''          %C(dim white)- %an <%ae> %C(reset) %C(dim white)(committer: %cn <%ce>)%C(reset)'
+  pushb = !"git push --set-upstream <(git remote) <(git symbolic-ref HEAD --short)"


### PR DESCRIPTION
This allows me to use 

```sh
git pushb
```

instead of 

```sh
git push --set-upstream origin DESCRIPTIVE-BRANCH-NAME-THAT-I-MIGHT-MISTYPE
``` 